### PR TITLE
nmap os service scan changes

### DIFF
--- a/robonmap/RoboNmap.py
+++ b/robonmap/RoboNmap.py
@@ -105,9 +105,9 @@ class RoboNmap(object):
         '''
         target = str(target)
         if portlist:
-            nmap_proc_cmd = "-Pn -sV --version-intensity {0} -p {1}".format(portlist, version_intense)
+            nmap_proc_cmd = "-Pn -sV --version-intensity {0} -p {1}".format(version_intense, portlist)
         else:
-            nmap_proc_cmd = "-Pn -sV --version-intensity {0}".format(portlist)
+            nmap_proc_cmd = "-Pn -sV --version-intensity {0}".format(version_intense)
 
         if file_export:
             nmap_proc_cmd += " -oN {0}".format(file_export)


### PR DESCRIPTION
nmap_os_service_scan keyword had an issue while passing arguments version_intense and portlist which were getting saved conversely. This change is to fix that issue.